### PR TITLE
Add RC4 to crypto

### DIFF
--- a/dpapick3/blob.py
+++ b/dpapick3/blob.py
@@ -92,7 +92,12 @@ class DPAPIBlob(eater.DataStruct):
         for algo in [crypto.CryptSessionKeyType1, crypto.CryptSessionKeyType2]:
             sessionkey = algo(masterkey, self.salt, self.hashAlgo, entropy=entropy, smartcardsecret=smartCardSecret, strongPassword=strongPassword)
             key = crypto.CryptDeriveKey(sessionkey, self.cipherAlgo, self.hashAlgo)
-            cipher = self.cipherAlgo.module.new(key[:int(self.cipherAlgo.keyLength)],
+            #RC4 is a stream cipher, and so we need to call module without the mode parameter
+            if self.cipherAlgo == "RC4":
+              cipher =  self.cipherAlgo.module.new(key[:int(self.cipherAlgo.keyLength)],
+                                                  IV=b'\x00' * int(self.cipherAlgo.ivLength))
+            else:
+              cipher = self.cipherAlgo.module.new(key[:int(self.cipherAlgo.keyLength)],
                                                 mode=self.cipherAlgo.module.MODE_CBC,
                                                 IV=b'\x00' * int(self.cipherAlgo.ivLength))
             self.cleartext = cipher.decrypt(self.cipherText)

--- a/dpapick3/crypto.py
+++ b/dpapick3/crypto.py
@@ -102,6 +102,7 @@ CryptoAlgo.add_algo(0x660f, name="AES-192", keyLength=192, IVLength=128, blockLe
 CryptoAlgo.add_algo(0x6610, name="AES-256", keyLength=256, IVLength=128, blockLength=128, module=AES)
 CryptoAlgo.add_algo(0x6601, name="DES", keyLength=64, IVLength=64, blockLength=64, module=DES,
                     keyFixup=des_set_odd_parity)
+CryptoAlgo.add_algo(0x6801, name="RC4", keyLength=40, IVLength=16, blockLength=1, module=ARC4)
 
 CryptoAlgo.add_algo(0x8009, name="HMAC", digestLength=160, blockLength=512)
 

--- a/dpapick3/crypto.py
+++ b/dpapick3/crypto.py
@@ -102,7 +102,7 @@ CryptoAlgo.add_algo(0x660f, name="AES-192", keyLength=192, IVLength=128, blockLe
 CryptoAlgo.add_algo(0x6610, name="AES-256", keyLength=256, IVLength=128, blockLength=128, module=AES)
 CryptoAlgo.add_algo(0x6601, name="DES", keyLength=64, IVLength=64, blockLength=64, module=DES,
                     keyFixup=des_set_odd_parity)
-CryptoAlgo.add_algo(0x6801, name="RC4", keyLength=40, IVLength=16, blockLength=1, module=ARC4)
+CryptoAlgo.add_algo(0x6801, name="RC4", keyLength=40, IVLength=128, blockLength=1, module=ARC4)
 
 CryptoAlgo.add_algo(0x8009, name="HMAC", digestLength=160, blockLength=512)
 


### PR DESCRIPTION
Windows 2000 DPAPI objects can use RC4. Currently trying to parse one of these blobs crashes DPAPIck3